### PR TITLE
Use pulp.cmd on windows.

### DIFF
--- a/pulp.sublime-build
+++ b/pulp.sublime-build
@@ -2,9 +2,15 @@
     "selector": "source.purescript",
     "cmd": ["pulp", "test"],
     "working_dir": "${file_path}",
+    "windows": {
+        "cmd": ["pulp.cmd", "test"]
+    },
     "variants": [
         { "name": "Run",
-          "cmd": ["pulp", "run"]
+          "cmd": ["pulp", "run"],
+          "windows": {
+              "cmd": ["pulp.cmd", "run"]
+          }
         }
     ]
 }


### PR DESCRIPTION
This little fix should enable sublime to invoke pulp correctly on windows.
